### PR TITLE
Removed zlib requirement from package.json. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 
   "name": "virtualenv",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "install and use Python dependencies in node with virtualenv",
 
   "keywords": [
@@ -16,7 +16,9 @@
   },
 
   "main": "./lib/virtualenv.js",
-
+  "engines": {
+      "node": ">=0.6"
+  },
   "dependencies": {
 
     "request": "2.x",


### PR DESCRIPTION
Zlib is included in latest Node. Zlib in npm is outdated and broken. Virtualenv install fails because of this. Is there perhaps a way to specify this dependency for users of older Nodejs without breaking things for new users?
