### PR TITLE
Added support to specify python interpreter in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Send flags to the virtualenv creation command:
   }
 ```
 
+Launch virtualenv.py using a specific python interpreter
+
+```javascript
+  "virtualenv": {
+    "python": "/path/to/my/python"
+  }
+```
+
+
 ## References
 
 * Official [virtualenv documentation](http://www.virtualenv.org/en/latest/)

--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -238,7 +238,7 @@ VirtualEnv.prototype._create = function _create(version, callback) {
 
   // Create new virtualenv in ".node-virtualenv"
   var sourcePath = this._getPathToSourceForVersion(version);
-  var cmd = ["python virtualenv.py"].concat(this._createFlags).concat([this._virtualenvHome]).join(' ');
+  var cmd = [this._createPython, "virtualenv.py"].concat(this._createFlags).concat([this._virtualenvHome]).join(' ');
 
   childProcess.exec(cmd, {cwd: sourcePath}, function(error, stdout, stderr) {
       if (error) {
@@ -247,19 +247,6 @@ VirtualEnv.prototype._create = function _create(version, callback) {
       callback();
     }
   );
-
-  var createProc = childProcess.spawn("python",
-  var createProc = childProcess.spawn(this._createPython,
-    ["virtualenv.py"].concat(this._createFlags).concat([this._virtualenvHome]),
-    {cwd: sourcePath}
-  );
-  createProc.stderr.pipe(this._stderr);
-  createProc.stdout.pipe(this._stdout);
-  createProc.on("exit", function(code) {
-    if (code) return callback(new Error("Error while creating virtualenv: exit " + code));
-    callback();
-  }.bind(this));
-
 }
 
 VirtualEnv.prototype._pip = function _pip(callback) {

--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -126,7 +126,7 @@ VirtualEnv.prototype.spawn = function spawn(command, args, options) {
 }
 
 VirtualEnv.prototype.spawnPython = function spawnPython(args, options) {
-  var pathToPython = path.join(this._virtualenvHome, "bin", this._createPython);
+  var pathToPython = path.join(this._virtualenvHome, "bin", "python");
   return childProcess.spawn(pathToPython, args, options);
 }
 
@@ -238,7 +238,7 @@ VirtualEnv.prototype._create = function _create(version, callback) {
 
   // Create new virtualenv in ".node-virtualenv"
   var sourcePath = this._getPathToSourceForVersion(version);
-  var createProc = childProcess.spawn("python",
+  var createProc = childProcess.spawn(this._createPython,
     ["virtualenv.py"].concat(this._createFlags).concat([this._virtualenvHome]),
     {cwd: sourcePath}
   );

--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -238,15 +238,17 @@ VirtualEnv.prototype._create = function _create(version, callback) {
 
   // Create new virtualenv in ".node-virtualenv"
   var sourcePath = this._getPathToSourceForVersion(version);
-  var cmd = [this._createPython, "virtualenv.py"].concat(this._createFlags).concat([this._virtualenvHome]).join(' ');
-
-  childProcess.exec(cmd, {cwd: sourcePath}, function(error, stdout, stderr) {
-      if (error) {
-        callback(new Error("Error while creating virtualenv: exit " + error.code))
-      }
-      callback();
-    }
+  var createProc = childProcess.spawn(this._createPython,
+    ["virtualenv.py"].concat(this._createFlags).concat([this._virtualenvHome]),
+    {cwd: sourcePath}
   );
+  createProc.stderr.pipe(this._stderr);
+  createProc.stdout.pipe(this._stdout);
+  createProc.on("exit", function(code) {
+    if (code) return callback(new Error("Error while creating virtualenv: exit " + code));
+    callback();
+  }.bind(this));
+
 }
 
 VirtualEnv.prototype._pip = function _pip(callback) {

--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -25,6 +25,7 @@ function VirtualEnv(packagePath) {
   package.virtualenv = package.virtualenv || {};
   this._version = package.virtualenv.version || "*";
   this._createFlags = package.virtualenv.flags || [];
+  this._createPython = package.virtualenv.python || "python";
 
   // Read requirements from requirements.txt if it exists.
   this._requirements = path.join(path.dirname(packagePath), "requirements.txt");
@@ -125,7 +126,7 @@ VirtualEnv.prototype.spawn = function spawn(command, args, options) {
 }
 
 VirtualEnv.prototype.spawnPython = function spawnPython(args, options) {
-  var pathToPython = path.join(this._virtualenvHome, "bin", "python");
+  var pathToPython = path.join(this._virtualenvHome, "bin", this._createPython);
   return childProcess.spawn(pathToPython, args, options);
 }
 

--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -25,7 +25,7 @@ function VirtualEnv(packagePath) {
   package.virtualenv = package.virtualenv || {};
   this._version = package.virtualenv.version || "*";
   this._createFlags = package.virtualenv.flags || [];
-  this._createPython = package.virtualenv.python || "python";
+  this._python = package.virtualenv.python || "python";
 
   // Read requirements from requirements.txt if it exists.
   this._requirements = path.join(path.dirname(packagePath), "requirements.txt");
@@ -238,7 +238,7 @@ VirtualEnv.prototype._create = function _create(version, callback) {
 
   // Create new virtualenv in ".node-virtualenv"
   var sourcePath = this._getPathToSourceForVersion(version);
-  var createProc = childProcess.spawn(this._createPython,
+  var createProc = childProcess.spawn(this._python,
     ["virtualenv.py"].concat(this._createFlags).concat([this._virtualenvHome]),
     {cwd: sourcePath}
   );


### PR DESCRIPTION
On some machines, setting the venv flag "-p python3" was not sufficient; the system would create a python2 virtualenv...  setting python to "python3" resolves that problem without changing anything else on the system.
