### PR TITLE
Fix for virtualenv issue 596 (long path names)

### DIFF
--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -250,8 +250,8 @@ VirtualEnv.prototype._pip = function _pip(callback) {
 
   // Install Python dependencies into the virtualenv created in the create step.
   this._reportProgress("Installing", this._virtualenvHome);
-  var pipProc = childProcess.spawn("bin/pip",
-    ["install", "-r", this._requirements],
+  var pipProc = childProcess.spawn("bin/python",
+    ["-m", "pip", "install", "-r", this._requirements],
     {cwd: this._virtualenvHome}
   );
   pipProc.stderr.pipe(this._stderr);


### PR DESCRIPTION
This is a fix for https://github.com/pypa/virtualenv/issues/596

Simply not calling the pip executable directly, invoking `python -m pip` instead,