### PR TITLE
Fix "depend on a specific version" of virtualenv.

### DIFF
--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -178,14 +178,12 @@ VirtualEnv.prototype._find = function _find(callback) {
     // Propagate pypi error callback.
     }, function(err) {
       callback(new Error("unable to retrieve release URLs for virtualenv " + latestValidVersion));
-    },
-    true);
+    });
 
   // Propagate pypi error callback.
   }, function(err) {
     callback(new Error("unable to retrieve version information for virtualenv"));
-  });
-
+  }, true);
 }
 
 VirtualEnv.prototype._download = function _download(url, callback) {

--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -146,8 +146,14 @@ VirtualEnv.prototype._find = function _find(callback) {
 
     // Find the latest valid version.
     var latestValidVersion;
-    versions.sort(function(a, b) {
-      return semver.lt(a, b);
+    versions.map(function(version) {
+        return semver.coerce(version);
+    }).filter(function(version) {
+        return version;
+    }).map(function(version) {
+        return version.raw;
+    }).sort(function(a, b) {
+        return semver.lt(a, b);
     }).some(function(version) {
       if (semver.satisfies(version, targetVersion)) {
         latestValidVersion = version;
@@ -172,7 +178,8 @@ VirtualEnv.prototype._find = function _find(callback) {
     // Propagate pypi error callback.
     }, function(err) {
       callback(new Error("unable to retrieve release URLs for virtualenv " + latestValidVersion));
-    });
+    },
+    true);
 
   // Propagate pypi error callback.
   }, function(err) {

--- a/package.json
+++ b/package.json
@@ -1,45 +1,34 @@
 {
-
   "name": "virtualenv",
   "version": "0.3.1",
   "description": "install and use Python dependencies in node with virtualenv",
-
   "keywords": [
     "python",
     "virtualenv",
     "rpc"
   ],
-
   "repository": {
-      "type": "git",
-      "url": "https://github.com/mjpizz/node-virtualenv.git"
+    "type": "git",
+    "url": "https://github.com/mjpizz/node-virtualenv.git"
   },
-
   "main": "./lib/virtualenv.js",
   "engines": {
-      "node": ">=0.6"
+    "node": ">=0.6"
   },
-
   "dependencies": {
-
     "request": "2.x",
-    "rimraf": "2.x",
-    "glob": "3.x",
+    "rimraf": "3.x",
+    "glob": "7.x",
     "tar": "2.x",
     "semver": "5.x",
-    "xmlrpc": "0.8.x"
-
+    "xmlrpc": "1.3.x"
   },
-
   "bin": {
     "virtualenv-postinstall": "./bin/postinstall"
   },
-
   "license": "MIT",
-
   "author": {
     "name": "Matt Pizzimenti",
     "url": "http://mjpizz.com"
   }
-
 }


### PR DESCRIPTION
Adds showHidden = true to getPackageReleases call and converts version numbers to semver fromat before finding the match.

Now it should be possible to include the following in package.json and to stick to specific version of virtualenv:

 "virtualenv": {
   "version": "16.0.0"
 }