### PR TITLE
Fixing bug due to virtualenv.py moving location in source

### DIFF
--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -288,7 +288,7 @@ VirtualEnv.prototype._setMeta = function _setMeta(key, value) {
 }
 
 VirtualEnv.prototype._getPathToSourceForVersion = function _getPathToSourceForVersion(version) {
-  return path.join(this._virtualenvSourcesHome, "virtualenv-" + version)
+  return path.join(this._virtualenvSourcesHome, "virtualenv-" + version, "src")
 }
 
 VirtualEnv.prototype._virtualenvIsUnchanged = function _virtualenvIsUnchanged() {


### PR DESCRIPTION
I couldn't get this working due to:

```
python: can't open file 'virtualenv.py': [Errno 2] No such file or directory
```

Inspecting the source reveals this is now located inside a `src/` subdirectory, hence this PR.